### PR TITLE
Merge 7.0 2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -43,6 +43,19 @@ smartmontools (7.0-1) unstable; urgency=medium
 
  -- Dmitry Smirnov <onlyjob@debian.org>  Thu, 10 Oct 2019 12:39:16 +1100
 
+smartmontools (7.0-0ubuntu1) eoan; urgency=medium
+
+  * New upstream release.
+  * d/p/{kfreebsd,removesyslogtarget}.patch: Drop, included upstream.
+  * d/p/*: Refresh.
+  * d/watch: Tweak pattern match for tar.* release artefacts.
+  * d/control,rules: Enable direct support for systemd.
+  * d/p/disable-systemd.patch: Disable Type=notify to mimic behaviour
+    of prior versions of smartmontools in deployments where no
+    SMART capable devices are detected.
+
+ -- James Page <james.page@ubuntu.com>  Fri, 24 May 2019 09:17:16 +0100
+
 smartmontools (6.6-1) unstable; urgency=medium
 
   [ Jonathan Dowland ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+smartmontools (7.0-2ubuntu1) focal; urgency=medium
+
+  * Merge with Debian unstable. Remaining changes:
+    - d/p/disable-systemd.patch: Disable Type=notify to mimic behaviour
+      of prior versions of smartmontools in deployments where no
+      SMART capable devices are detected.
+  * Dropped:
+    - d/control,rules: Enable direct support for systemd.
+      [In 7.0-2]
+
+ -- Lucas Kanashiro <lucas.kanashiro@canonical.com>  Wed, 04 Dec 2019 09:01:23 -0300
+
 smartmontools (7.0-2) unstable; urgency=medium
 
   * SysV: don't (re)start daemon during upgrade (Closes: #942118).

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: smartmontools
 Section: utils
 Priority: optional
 Standards-Version: 4.4.1
-Maintainer: Dmitry Smirnov <onlyjob@debian.org>
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+XSBC-Original-Maintainer: Dmitry Smirnov <onlyjob@debian.org>
 Uploaders: Florian Maier <contact@marsmenschen.com>,
            Jonathan Dowland <jmtd@debian.org>,
 Build-Depends: autoconf,

--- a/debian/patches/disable-systemd.patch
+++ b/debian/patches/disable-systemd.patch
@@ -1,0 +1,18 @@
+Description: Disable systemd notify integration
+ Use of systemd-dev and notify causes the systemd unit to
+ fail on deployments where no devices are detected with
+ SMART capabilities; switch back to default systemd unit
+ type to avoid package install/upgrade failures.
+Author: James Page <james.page@ubuntu.com>
+Forwarded: not-needed
+
+--- a/smartd.service.in
++++ b/smartd.service.in
+@@ -3,7 +3,6 @@ Description=Self Monitoring and Reportin
+ Documentation=man:smartd(8) man:smartd.conf(5)
+ 
+ [Service]
+-Type=notify
+ EnvironmentFile=-/usr/local/etc/sysconfig/smartmontools
+ ExecStart=/usr/local/sbin/smartd -n $smartd_opts
+ ExecReload=/bin/kill -HUP $MAINPID

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@
 manpage.diff
 service-alias.patch
 unknown-formfactor.patch
+disable-systemd.patch


### PR DESCRIPTION
Merge version 7.0-2 from Debian. Those are the changes in the current Ubuntu package (7.0-0ubuntu1):

  * New upstream release.
  * d/p/{kfreebsd,removesyslogtarget}.patch: Drop, included upstream.
  * d/p/*: Refresh.
  * d/watch: Tweak pattern match for tar.* release artefacts.
  * d/control,rules: Enable direct support for systemd.
  * d/p/disable-systemd.patch: Disable Type=notify to mimic behaviour
    of prior versions of smartmontools in deployments where no
    SMART capable devices are detected.

Just the systemd patch was kept and the remaining was already fixed upstream. BTW the debian/watch change mentioned in the changelog actually is a mistake because no change in debian/watch was introduced in this upload.

I also added another change because Debian maintainer created a broken symlink in the debian directory (debian/smartmontools.service -> smartd.service) which will be fixed in build time (when the smartd.service file is generated). Instead of having a broken symlink I simply rename the file during the installation, a much cleaner solution IMO.

Here is the PPA were this package was built in all architectures: https://launchpad.net/~lucaskanashiro/+archive/ubuntu/focal-smartmontools-merge-7.0-2